### PR TITLE
fix: Make plugins wont work as a target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 clean:
 	rm -rf apps
 
-plugins: 
+build-plugins: 
 	cargo build --target wasm32-unknown-unknown --release --manifest-path plugins/invert/Cargo.toml
 	cargo build --target wasm32-unknown-unknown --release --manifest-path plugins/md2html/Cargo.toml
 	

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use the filesystem as a computing environment.
 Make sure you have Extism installed: https://extism.org/docs/install
 
 ```sh
-make plugins # requires Rust toolchain
+make build-plugins # requires Rust toolchain
 make run # requires Go toolchain
 ```
 


### PR DESCRIPTION
`make plugins` doesn't work as a target due to the `plugins` folder:

```
make: `plugins' is up to date.
```